### PR TITLE
Add default hit and miss action and a few usability improvements

### DIFF
--- a/etc/iproute2/introspection/ptables
+++ b/etc/iproute2/introspection/ptables
@@ -22,27 +22,27 @@ key randomKey2 bit32 1
 key randomKey3 bit64 1
 
 header ethernet 22 1
-field dstAddr macaddr 1
-field srcAddr macaddr 2
-field type bit16 14
+field dstAddr macaddr 1 1
+field srcAddr macaddr 2 1
+field type bit16 14 1
 
 header ipv4 22 2
-field version bit4 15
-field ihl bit4 5
-field tos bit8 6
-field totlen bit16 7
-field id bit16 8
-field flags bit3 9
-field fragoff bit13 10
-field ttl bit8 11
-field proto bit8 12
-field checksum bit16 13
-field srcAddr ipv4 3
-field dstAddr ipv4 4
+field version bit4 15 1
+field ihl bit4 5 1
+field tos bit8 6 1
+field totlen bit16 7 1
+field id bit16 8 1
+field flags bit3 9 1
+field fragoff bit13 10 1
+field ttl bit8 11 1
+field proto bit8 12 1
+field checksum bit16 13 1
+field srcAddr ipv4 3 1
+field dstAddr ipv4 4 1
 
 header tcp 22 3
-field srcPort bit16 16
-field dstPort bit16 17
+field srcPort bit16 16 1
+field dstPort bit16 17 1
 
 metadata mymd bit32 22 1
 metadata mytest bit16 22 2

--- a/etc/iproute2/introspection/simple_l3_pna
+++ b/etc/iproute2/introspection/simple_l3_pna
@@ -5,27 +5,27 @@ table MainControlImpl/l3_match_rx 1 1
 key dstAddr ipv4 1
 
 header ethernet 1 1
-field dstAddr macaddr 1
-field srcAddr macaddr 2
+field dstAddr macaddr 1 1
+field srcAddr macaddr 2 1
 field type bit16 14
 
 header ipv4 1 2
-field version bit4 15
-field ihl bit4 5
-field tos bit8 6
-field totlen bit16 7
-field id bit16 8
-field flags bit3 9
-field fragoff bit13 10
-field ttl bit8 11
-field proto bit8 12
-field checksum bit16 13
-field srcAddr ipv4 3
-field dstAddr ipv4 4
+field version bit4 15 1
+field ihl bit4 5 1
+field tos bit8 6 1
+field totlen bit16 7 1
+field id bit16 8 1
+field flags bit3 9 1
+field fragoff bit13 10 1
+field ttl bit8 11 1
+field proto bit8 12 1
+field checksum bit16 13 1
+field srcAddr ipv4 3 1
+field dstAddr ipv4 4 1
 
 header tcp 22 3
-field srcPort bit16 16
-field dstPort bit16 17
+field srcPort bit16 16 1
+field dstPort bit16 17 1
 
 metadata mymd bit32 1 1
 metadata mytest bit16 1 2

--- a/include/uapi/linux/p4tc.h
+++ b/include/uapi/linux/p4tc.h
@@ -191,6 +191,8 @@ enum {
 	P4TC_TCLASS_PREACTIONS, /* nested table preactions */
 	P4TC_TCLASS_KEYS, /* nested table keys */
 	P4TC_TCLASS_POSTACTIONS, /* nested table postactions */
+	P4TC_TCLASS_DEFAULT_HIT, /* default hit action */
+	P4TC_TCLASS_DEFAULT_MISS, /* default miss action */
 	__P4TC_TCLASS_MAX
 };
 #define P4TC_TCLASS_MAX __P4TC_TCLASS_MAX

--- a/tc/p4_tc_introspection.c
+++ b/tc/p4_tc_introspection.c
@@ -146,13 +146,14 @@ int p4tc_get_header_fields(struct hdrfield fields[], const char *pname,
 	while (getline(&line, &len, f) != -1) {
 		__u32 bitsz = 0;
 		struct p4_type_s *p4_type;
+		__u32 parserid;
 		int scanned;
 		__u32 id;
 
-		scanned = sscanf(line, "%s %s %s %u[^\n]", field_str, field_name,
-				 type_str, &id);
+		scanned = sscanf(line, "%s %s %s %u %u[^\n]", field_str,
+				 field_name, type_str, &id, &parserid);
 
-		if (scanned != 4)
+		if (scanned != 5)
 			break;
 		if (strcmp(field_str, "field") != 0)
 			continue;
@@ -165,6 +166,7 @@ int p4tc_get_header_fields(struct hdrfield fields[], const char *pname,
 		}
 
 		fields[i].id = id;
+		fields[i].parserid = parserid;
 		fields[i].ty = p4_type;
 
 		fields[i].startbit = hdr_offset;

--- a/tc/p4_tc_template.c
+++ b/tc/p4_tc_template.c
@@ -1137,6 +1137,7 @@ static int parse_hdrfield_data(int *argc_p, char ***argv_p, struct nlmsghdr *n,
 		hdr_ty.startbit = field->startbit;
 		hdr_ty.endbit = field->endbit;
 
+		ids[0] = field->parserid;
 		ids[1] = field->id;
 	} else if (hdrfield_id) {
 		ids[1] = hdrfield_id;

--- a/tc/p4_tc_template.c
+++ b/tc/p4_tc_template.c
@@ -1445,6 +1445,24 @@ static int parse_table_class_data(int *argc_p, char ***argv_p,
 					return -1;
 				}
 				continue;
+			} else if (strcmp(*argv, "default_hit_action") == 0) {
+				argv++;
+				argc--;
+				if (parse_action(&argc, &argv,
+						 P4TC_TCLASS_DEFAULT_HIT | NLA_F_NESTED, n)) {
+					fprintf(stderr, "Illegal action\n");
+					return -1;
+				}
+				continue;
+			} else if (strcmp(*argv, "default_miss_action") == 0) {
+				argv++;
+				argc--;
+				if (parse_action(&argc, &argv,
+						 P4TC_TCLASS_DEFAULT_MISS | NLA_F_NESTED, n)) {
+					fprintf(stderr, "Illegal action\n");
+					return -1;
+				}
+				continue;
 			} else {
 				fprintf(stderr, "Unknown arg %s\n", *argv);
 				return -1;

--- a/tc/p4tc_introspection.h
+++ b/tc/p4tc_introspection.h
@@ -40,6 +40,7 @@ struct hdrfield {
 	char name[TEMPLATENAMSZ];
 	struct p4_type_s *ty;
 	__u32 id;
+	__u32 parserid;
 	__u16 startbit;
 	__u16 endbit;
 };


### PR DESCRIPTION
- Don't require user to specify parserid when creating a header field via command line
- Add default hit and miss action options to table class command line

