### PR TITLE
Don't expect key_id for table in introspection JSON

### DIFF
--- a/tc/p4_tc_json.c
+++ b/tc/p4_tc_json.c
@@ -244,14 +244,6 @@ static int json_parse_table(cJSON *table_cjson, struct table *table)
 		return -1;
 	}
 
-	ret = cjson_get_int(table_cjson, JSON_TABLE_LIST_TABLE_KEY_ID, &keyid);
-	if (ret) {
-		fprintf(stderr, "Failed to parse table keyid:<%s> for:\n<%s>\n",
-			JSON_TABLE_LIST_TABLE_KEY_ID,
-			cJSON_Print(table_cjson));
-		return -1;
-	}
-
 	ret = cjson_get_int(table_cjson, JSON_TABLE_LIST_TABLE_SIZE, &size);
 	if (ret) {
 		fprintf(stderr, "Failed to parse table size:<%s> for:\n<%s>\n",

--- a/tc/p4_tc_json_infra.h
+++ b/tc/p4_tc_json_infra.h
@@ -16,7 +16,6 @@
 #define JSON_TABLE_LIST_TABLE_ID "id"
 #define JSON_TABLE_LIST_TABLE_SIZE "tentries"
 #define JSON_TABLE_LIST_TABLE_KEYS "keyfields"
-#define JSON_TABLE_LIST_TABLE_KEY_ID "keyid"
 #define JSON_TABLE_LIST_TABLE_KEY_SIZE "keysize"
 #define JSON_TABLE_LIST_TABLE_KEY_FIELD_ID "id" //keyfield id
 #define JSON_TABLE_LIST_TABLE_KEY_NAME "name"


### PR DESCRIPTION
Remove requirement of legacy field "key_id" from table dictionary in JSON file